### PR TITLE
Avoid encoding numeric values as datetime

### DIFF
--- a/jsondatetime/tests/test_jsondatetime.py
+++ b/jsondatetime/tests/test_jsondatetime.py
@@ -40,6 +40,18 @@ class TestBase(TestCase):
         self.assertIs(type(decoded), datetime.datetime)
         self.assertEqual(decoded, self.expected)
 
+    def test_numeric_value(self):
+        decoded = json.loads('{"key": "2"}')
+        self.assertEqual(decoded.get('key'), "2")
+
+    def test_float_value(self):
+        decoded = json.loads('{"key": "2.5"}')
+        self.assertEqual(decoded.get('key'), "2.5")
+
+    def test_json_dumps(self):
+        json.dumps({"x": 1})
+
+
     def hook(self, dct):
         dct["hookjob"] = "I'm hooked!"
         return dct


### PR DESCRIPTION
1. In case numeric value is provided as a str, i.e. "2", we don't want to convert it to datetime. Same for float value, i.e. 8.5
2. Add python3 support for json.dumps