### PR TITLE
Fixes PyPI name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,4 +46,4 @@ still perform custom parsing of your inbound JSON stream.
 
 Installation
 ------------
-``pip install json-datetime``
+``pip install JSON-Datetime``


### PR DESCRIPTION
Although PyPI names aren't case sensitive and `pip` will resolve it correctly, it might be good to have the exact match here.